### PR TITLE
Remove check for the executable to be in /Applications

### DIFF
--- a/ProtonDrive-macOS/ProtonDriveMac/AppDelegate.swift
+++ b/ProtonDrive-macOS/ProtonDriveMac/AppDelegate.swift
@@ -55,15 +55,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         super.init()
 
         setUpExtensionLaunchObserver()
-
-#if !HAS_QA_FEATURES
-        let executablePath = Bundle.main.executablePath ?? ""
-        if executablePath.hasPrefix("/Applications/") == false {
-            Task {
-                await handleError(NSError(domain: "", code: -1, responseDictionary: nil, localizedDescription: "This application must be run from the /Applications folder. \n  Please move it there and run it again."))
-            }
-        }
-#endif
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {


### PR DESCRIPTION
Sry, for doing it this way but I'm not sure how to get in touch with you.

I'm packaging Proton Drive for nixpkgs (https://github.com/NixOS/nixpkgs/pull/493395). However, the production build has a hardcoded restriction that only allows executable paths starting with `/Applications`, which breaks Proton Drive when installed via Nix.

Nix installs applications to the immutable `/nix/store` directory and then creates symlinks to:
- `/Users/<user>/Applications/Home Manager Apps/` (when using home-manager)
- `/Applications/Nix Apps/` (when using nix directly)

Since these symlink locations don't always match the `/Applications` requirement, Proton Drive fails to launch.

### Questions

1. Why does Proton Drive enforce this `/Applications` path check? 
2. Would you be open to relaxing this restriction?